### PR TITLE
feat: add Docker auto-build workflow and WebUI support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,83 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (leave empty to use "dev")'
+        required: false
+        default: 'dev'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - dockerfile: docker/Dockerfile
+            suffix: ""
+            description: "Base image with tg-signer"
+          - dockerfile: docker/Dockerfile.webui
+            suffix: "-webui"
+            description: "Image with WebUI support"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=${{ matrix.suffix }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=tag
+            type=raw,value=${{ github.event.inputs.tag || 'dev' }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest${{ matrix.suffix }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            TZ=Asia/Shanghai
+
+      - name: Image digest
+        run: echo "Image pushed with digest ${{ steps.meta.outputs.digest }}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,7 +63,7 @@ jobs:
             type=semver,pattern={{major}}
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.tag || 'dev' }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=latest${{ matrix.suffix }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/docker/Dockerfile.webui
+++ b/docker/Dockerfile.webui
@@ -1,0 +1,31 @@
+FROM python:3.12-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y gcc && \
+    mkdir -p build && \
+    pip wheel -w build tgcrypto
+
+FROM python:3.12-slim
+
+ARG TZ=Asia/Shanghai
+ENV TZ=${TZ}
+ENV DEBIAN_FRONTEND=noninteractive
+COPY --from=builder /build/*.whl /tmp/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install /tmp/*.whl && \
+    pip install -U "tg-signer[speedup,gui]"
+
+WORKDIR /opt/tg-signer
+
+# WebUI default port
+EXPOSE 8080
+
+# Default command to start WebUI
+# --host 0.0.0.0 allows access from outside container
+# --auth-code should be set via environment variable TG_SIGNER_GUI_AUTHCODE
+CMD ["tg-signer", "webgui", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 ## 快速开始
 
 ```bash
-# 1. 创建目录
+# 1. 创建目录并进入
 mkdir -p /opt/tg-signer/data && cd /opt/tg-signer
 
 # 2. 下载 docker-compose.yml
@@ -12,49 +12,52 @@ curl -O https://raw.githubusercontent.com/htazq/tg-signer/main/docker/docker-com
 # 3. 启动容器
 docker compose up -d
 
-# 4. 进入容器完成登录和配置
+# 4. 进入容器
 docker exec -it tg-signer bash
 ```
 
-## 使用流程
+## 首次配置
 
-### 1. 登录 Telegram（必须在命令行完成）
+在容器内执行：
 
 ```bash
-docker exec -it tg-signer bash
+# 1. 登录 Telegram
 tg-signer login
 # 按提示输入手机号和验证码
-```
 
-### 2. 配置签到任务
-
-```bash
+# 2. 配置签到任务
 tg-signer run my_task
 # 按提示配置 Chat ID、签到时间、动作等
+# 配置完成后 Ctrl+C 退出
+
+# 3. 退出容器
+exit
 ```
 
-### 3. 运行任务
+## 启动任务
 
-配置完成后，修改 `docker-compose.yml` 添加启动命令：
+配置完成后，修改 `docker-compose.yml`：
 
 ```yaml
-services:
-  tg-signer:
-    image: ghcr.io/htazq/tg-signer:latest
+    # 注释掉这行
+    # command: ["sleep", "infinity"]
+    # 取消注释并填入任务名
     command: ["tg-signer", "run", "任务名1", "任务名2"]
-    # ... 其他配置
 ```
 
-然后重启：`docker compose up -d`
+然后重启：
 
-任务会在后台按配置的时间自动执行。
+```bash
+docker compose up -d
+docker logs -f tg-signer  # 查看日志确认运行正常
+```
 
 ## 镜像说明
 
 | 镜像 | 内存占用 | 说明 |
 |------|----------|------|
 | `ghcr.io/htazq/tg-signer:latest` | ~70MB | 推荐，CLI 版 |
-| `ghcr.io/htazq/tg-signer:latest-webui` | ~110MB | 包含 Web 配置界面 |
+| `ghcr.io/htazq/tg-signer:latest-webui` | ~110MB | 包含 Web 管理界面 |
 
 支持平台：`linux/amd64`、`linux/arm64`
 
@@ -64,7 +67,6 @@ services:
 |------|------|
 | `TG_PROXY` | 代理地址，如 `socks5://host:port` |
 | `TZ` | 时区，默认 `Asia/Shanghai` |
-| `TG_SIGNER_GUI_AUTHCODE` | WebUI 访问密码（仅 webui 版） |
 
 ## 常用命令
 
@@ -74,6 +76,9 @@ docker logs -f tg-signer
 
 # 列出已配置的任务
 docker exec tg-signer tg-signer list
+
+# 手动执行一次签到
+docker exec tg-signer tg-signer run-once 任务名
 
 # 更新镜像
 docker compose pull && docker compose up -d

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,58 +9,62 @@ mkdir -p /opt/tg-signer/data && cd /opt/tg-signer
 # 2. 下载 docker-compose.yml
 curl -O https://raw.githubusercontent.com/htazq/tg-signer/main/docker/docker-compose.yml
 
-# 3. (可选) 修改访问密码
-vi docker-compose.yml
-
-# 4. 启动
+# 3. 启动容器
 docker compose up -d
 
-# 5. 访问 http://your-ip:8080 进行配置
+# 4. 进入容器完成登录和配置
+docker exec -it tg-signer bash
 ```
 
 ## 使用流程
 
-### 首次配置
+### 1. 登录 Telegram（必须在命令行完成）
 
-1. 访问 `http://your-ip:8080`，输入访问密码
-2. 在 WebUI 中完成 **Telegram 登录**
-3. **创建签到任务**：配置 Chat ID、签到时间、动作等
-4. 点击 **"运行"** 按钮启动任务
-5. 任务会在后台按配置的时间自动执行
+```bash
+docker exec -it tg-signer bash
+tg-signer login
+# 按提示输入手机号和验证码
+```
 
-> 💡 配置完成后不需要保持浏览器打开，任务会在容器内自动运行
+### 2. 配置签到任务
 
-### (可选) 切换到 CLI 版本节省资源
+```bash
+tg-signer run my_task
+# 按提示配置 Chat ID、签到时间、动作等
+```
 
-配置完任务后，如果想节省内存（~70MB vs ~110MB），可以切换到 CLI 版：
+### 3. 运行任务
+
+配置完成后，修改 `docker-compose.yml` 添加启动命令：
 
 ```yaml
-# docker-compose.yml
 services:
   tg-signer:
-    image: ghcr.io/htazq/tg-signer:latest  # 改为 CLI 版
-    command: ["tg-signer", "run", "任务名1", "任务名2"]  # 添加此行
-    # ... 其他配置保持不变
+    image: ghcr.io/htazq/tg-signer:latest
+    command: ["tg-signer", "run", "任务名1", "任务名2"]
+    # ... 其他配置
 ```
 
 然后重启：`docker compose up -d`
+
+任务会在后台按配置的时间自动执行。
 
 ## 镜像说明
 
 | 镜像 | 内存占用 | 说明 |
 |------|----------|------|
-| `ghcr.io/htazq/tg-signer:latest-webui` | ~110MB | 推荐，包含 Web 管理界面 |
-| `ghcr.io/htazq/tg-signer:latest` | ~70MB | 仅 CLI，需配合 command 使用 |
+| `ghcr.io/htazq/tg-signer:latest` | ~70MB | 推荐，CLI 版 |
+| `ghcr.io/htazq/tg-signer:latest-webui` | ~110MB | 包含 Web 配置界面 |
 
 支持平台：`linux/amd64`、`linux/arm64`
 
 ## 环境变量
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `TG_SIGNER_GUI_AUTHCODE` | WebUI 访问密码 | - |
-| `TG_PROXY` | 代理地址 | - |
-| `TZ` | 时区 | Asia/Shanghai |
+| 变量 | 说明 |
+|------|------|
+| `TG_PROXY` | 代理地址，如 `socks5://host:port` |
+| `TZ` | 时区，默认 `Asia/Shanghai` |
+| `TG_SIGNER_GUI_AUTHCODE` | WebUI 访问密码（仅 webui 版） |
 
 ## 常用命令
 
@@ -68,25 +72,9 @@ services:
 # 查看日志
 docker logs -f tg-signer
 
-# 进入容器 (CLI 操作)
-docker exec -it tg-signer bash
-
 # 列出已配置的任务
 docker exec tg-signer tg-signer list
 
 # 更新镜像
 docker compose pull && docker compose up -d
-```
-
-## 本地构建
-
-```bash
-# WebUI 版
-docker build -t tg-signer:webui -f docker/Dockerfile.webui .
-
-# CLI 版
-docker build -t tg-signer -f docker/Dockerfile .
-
-# 中国镜像加速
-docker build -t tg-signer -f docker/CN.Dockerfile .
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,20 +9,50 @@ mkdir -p /opt/tg-signer/data && cd /opt/tg-signer
 # 2. 下载 docker-compose.yml
 curl -O https://raw.githubusercontent.com/htazq/tg-signer/main/docker/docker-compose.yml
 
-# 3. 启动
+# 3. (可选) 修改访问密码
+vi docker-compose.yml
+
+# 4. 启动
 docker compose up -d
 
-# 4. 访问 http://your-ip:8080
+# 5. 访问 http://your-ip:8080 进行配置
 ```
 
-## 镜像
+## 使用流程
 
-| 镜像 | 说明 |
-|------|------|
-| `ghcr.io/htazq/tg-signer:latest-webui` | WebUI 版 (推荐) |
-| `ghcr.io/htazq/tg-signer:latest` | 仅 CLI |
+### 首次配置
 
-支持 `linux/amd64` 和 `linux/arm64`
+1. 访问 `http://your-ip:8080`，输入访问密码
+2. 在 WebUI 中完成 **Telegram 登录**
+3. **创建签到任务**：配置 Chat ID、签到时间、动作等
+4. 点击 **"运行"** 按钮启动任务
+5. 任务会在后台按配置的时间自动执行
+
+> 💡 配置完成后不需要保持浏览器打开，任务会在容器内自动运行
+
+### (可选) 切换到 CLI 版本节省资源
+
+配置完任务后，如果想节省内存（~70MB vs ~110MB），可以切换到 CLI 版：
+
+```yaml
+# docker-compose.yml
+services:
+  tg-signer:
+    image: ghcr.io/htazq/tg-signer:latest  # 改为 CLI 版
+    command: ["tg-signer", "run", "任务名1", "任务名2"]  # 添加此行
+    # ... 其他配置保持不变
+```
+
+然后重启：`docker compose up -d`
+
+## 镜像说明
+
+| 镜像 | 内存占用 | 说明 |
+|------|----------|------|
+| `ghcr.io/htazq/tg-signer:latest-webui` | ~110MB | 推荐，包含 Web 管理界面 |
+| `ghcr.io/htazq/tg-signer:latest` | ~70MB | 仅 CLI，需配合 command 使用 |
+
+支持平台：`linux/amd64`、`linux/arm64`
 
 ## 环境变量
 
@@ -32,24 +62,17 @@ docker compose up -d
 | `TG_PROXY` | 代理地址 | - |
 | `TZ` | 时区 | Asia/Shanghai |
 
-## 代理配置
-
-```yaml
-environment:
-  # Docker Desktop (Mac/Windows)
-  - TG_PROXY=socks5://host.docker.internal:7890
-  # Linux
-  - TG_PROXY=socks5://172.17.0.1:7890
-```
-
 ## 常用命令
 
 ```bash
 # 查看日志
 docker logs -f tg-signer
 
-# 进入容器
+# 进入容器 (CLI 操作)
 docker exec -it tg-signer bash
+
+# 列出已配置的任务
+docker exec tg-signer tg-signer list
 
 # 更新镜像
 docker compose pull && docker compose up -d
@@ -58,11 +81,11 @@ docker compose pull && docker compose up -d
 ## 本地构建
 
 ```bash
-# 基础版
-docker build -t tg-signer -f docker/Dockerfile .
-
 # WebUI 版
 docker build -t tg-signer:webui -f docker/Dockerfile.webui .
+
+# CLI 版
+docker build -t tg-signer -f docker/Dockerfile .
 
 # 中国镜像加速
 docker build -t tg-signer -f docker/CN.Dockerfile .

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,242 +1,69 @@
 # tg-signer Docker 使用指南
 
-本目录包含 tg-signer 的 Docker 配置文件，支持多种部署方式。
-
-## 📦 镜像说明
-
-我们提供两种预构建镜像，托管在 GitHub Container Registry:
-
-| 镜像 | 说明 | 拉取命令 |
-|------|------|----------|
-| `ghcr.io/htazq/tg-signer:latest` | 基础版，仅 CLI | `docker pull ghcr.io/htazq/tg-signer:latest` |
-| `ghcr.io/htazq/tg-signer:latest-webui` | WebUI 版 | `docker pull ghcr.io/htazq/tg-signer:latest-webui` |
-
-**支持的平台**: `linux/amd64`, `linux/arm64`
-
-**版本标签**:
-- `latest` / `latest-webui` - 最新稳定版
-- `v0.8.4` / `v0.8.4-webui` - 指定版本
-- `dev` / `dev-webui` - 开发版本
-
----
-
-## 🚀 快速开始
-
-### 方式一: 使用 Docker Compose (推荐)
-
-1. **创建数据目录并进入 docker 目录**:
-   ```bash
-   cd docker
-   mkdir -p data
-   ```
-
-2. **启动 WebUI**:
-   ```bash
-   # 设置访问密码 (可选但强烈建议)
-   export AUTH_CODE="your_secure_password"
-   
-   # 启动
-   docker compose up -d webui
-   ```
-
-3. **访问 WebUI**: 打开浏览器访问 `http://localhost:8080`
-
-4. **在 WebUI 中完成**:
-   - 登录 Telegram 账号
-   - 配置签到任务或监控任务
-   - 设置定时运行
-
-### 方式二: 直接使用 Docker
+## 快速开始
 
 ```bash
-# 创建数据目录
-mkdir -p data
+# 1. 创建目录
+mkdir -p /opt/tg-signer/data && cd /opt/tg-signer
 
-# 启动 WebUI
-docker run -d \
-  --name tg-signer-webui \
-  -p 8080:8080 \
-  -v $(pwd)/data:/opt/tg-signer \
-  -e TG_SIGNER_GUI_AUTHCODE=your_password \
-  -e TZ=Asia/Shanghai \
-  ghcr.io/htazq/tg-signer:latest-webui
+# 2. 下载 docker-compose.yml
+curl -O https://raw.githubusercontent.com/htazq/tg-signer/main/docker/docker-compose.yml
+
+# 3. 启动
+docker compose up -d
+
+# 4. 访问 http://your-ip:8080
 ```
 
-### 方式三: CLI 交互模式
+## 镜像
 
-```bash
-# 启动容器进入交互模式
-docker run -it --rm \
-  -v $(pwd)/data:/opt/tg-signer \
-  -e TZ=Asia/Shanghai \
-  ghcr.io/htazq/tg-signer:latest \
-  bash
+| 镜像 | 说明 |
+|------|------|
+| `ghcr.io/htazq/tg-signer:latest-webui` | WebUI 版 (推荐) |
+| `ghcr.io/htazq/tg-signer:latest` | 仅 CLI |
 
-# 在容器内执行
-tg-signer login           # 登录
-tg-signer run my_task     # 配置并运行签到
-tg-signer monitor run     # 配置并运行监控
-```
+支持 `linux/amd64` 和 `linux/arm64`
 
----
-
-## ⚙️ 环境变量
+## 环境变量
 
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
-| `TZ` | 时区 | `Asia/Shanghai` |
-| `TG_PROXY` | 代理地址 | 无 |
-| `TG_ACCOUNT` | 账号名称 | `my_account` |
-| `TG_SIGNER_GUI_AUTHCODE` | WebUI 访问密码 | 无 (建议设置) |
-| `TG_SESSION_STRING` | Session 字符串 | 无 |
+| `TG_SIGNER_GUI_AUTHCODE` | WebUI 访问密码 | - |
+| `TG_PROXY` | 代理地址 | - |
+| `TZ` | 时区 | Asia/Shanghai |
 
-### 代理设置
+## 代理配置
 
-如果需要通过代理访问 Telegram:
+```yaml
+environment:
+  # Docker Desktop (Mac/Windows)
+  - TG_PROXY=socks5://host.docker.internal:7890
+  # Linux
+  - TG_PROXY=socks5://172.17.0.1:7890
+```
+
+## 常用命令
 
 ```bash
-# 使用宿主机代理 (Docker Desktop)
-export TG_PROXY=socks5://host.docker.internal:7890
-
-# 使用宿主机代理 (Linux)
-export TG_PROXY=socks5://172.17.0.1:7890
-
-# 使用其他代理服务器
-export TG_PROXY=socks5://your-proxy:1080
-```
-
----
-
-## 🔧 本地构建
-
-### 构建基础镜像
-
-```bash
-# 国际网络
-docker build -t tg-signer:latest -f Dockerfile ..
-
-# 中国网络 (使用镜像加速)
-docker build -t tg-signer:latest -f CN.Dockerfile ..
-```
-
-### 构建 WebUI 镜像
-
-```bash
-docker build -t tg-signer:webui -f Dockerfile.webui ..
-```
-
-### 指定时区构建
-
-```bash
-docker build --build-arg TZ=Europe/Paris -t tg-signer:latest -f Dockerfile ..
-```
-
----
-
-## 📁 目录结构
-
-```
-docker/
-├── Dockerfile           # 基础镜像
-├── Dockerfile.webui     # WebUI 镜像
-├── CN.Dockerfile        # 中国镜像加速版
-├── docker-compose.yml   # 标准 Compose 配置
-├── docker-compose.example.yml  # 完整配置示例
-└── README.md            # 本文档
-```
-
-挂载的数据目录结构:
-```
-data/
-├── my_account.session   # Telegram session 文件
-├── .signer/             # 配置和记录目录
-│   ├── signs/           # 签到任务
-│   ├── monitors/        # 监控任务
-│   └── ...
-└── logs/                # 日志目录
-```
-
----
-
-## 📋 Docker Compose 完整示例
-
-参考 `docker-compose.example.yml` 获取包含以下服务的完整配置:
-
-- **webui**: WebUI 管理界面 (端口 8080)
-- **signer**: 后台签到服务
-- **monitor**: 消息监控服务
-
-使用示例:
-```bash
-# 复制示例配置
-cp docker-compose.example.yml docker-compose.yml
-
-# 编辑配置
-vim docker-compose.yml
-
-# 启动 WebUI
-docker compose up -d webui
-
 # 查看日志
-docker compose logs -f
+docker logs -f tg-signer
 
-# 启动监控服务 (需要先取消 profiles)
-docker compose --profile monitor up -d
+# 进入容器
+docker exec -it tg-signer bash
+
+# 更新镜像
+docker compose pull && docker compose up -d
 ```
 
----
-
-## 🔄 更新镜像
+## 本地构建
 
 ```bash
-# 拉取最新镜像
-docker compose pull
+# 基础版
+docker build -t tg-signer -f docker/Dockerfile .
 
-# 重新创建容器
-docker compose up -d
+# WebUI 版
+docker build -t tg-signer:webui -f docker/Dockerfile.webui .
+
+# 中国镜像加速
+docker build -t tg-signer -f docker/CN.Dockerfile .
 ```
-
----
-
-## 🐛 常见问题
-
-### 1. 无法连接 Telegram
-
-检查代理配置是否正确:
-```bash
-docker exec -it tg-signer-webui bash
-# 在容器内测试
-curl -x $TG_PROXY https://api.telegram.org
-```
-
-### 2. Session 失效
-
-删除旧的 session 文件重新登录:
-```bash
-rm data/*.session
-docker compose restart webui
-```
-
-### 3. 查看日志
-
-```bash
-# 查看容器日志
-docker compose logs -f webui
-
-# 查看应用日志
-cat data/logs/tg-signer.log
-```
-
-### 4. 进入容器调试
-
-```bash
-docker exec -it tg-signer-webui bash
-```
-
----
-
-## 🔗 相关链接
-
-- [主项目文档](../README.md)
-- [GitHub 仓库](https://github.com/htazq/tg-signer)
-- [原作者仓库](https://github.com/amchii/tg-signer)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,69 +1,242 @@
-## 先决条件
+# tg-signer Docker 使用指南
 
-工作目录下添加`start.sh`:
+本目录包含 tg-signer 的 Docker 配置文件，支持多种部署方式。
 
-```sh
-pip install -U tg-signer
+## 📦 镜像说明
 
-# 首次配置时使用，后续注释掉
-sleep infinity
+我们提供两种预构建镜像，托管在 GitHub Container Registry:
 
-# 配置完成后取消注释
-# tg-signer run mytasks
+| 镜像 | 说明 | 拉取命令 |
+|------|------|----------|
+| `ghcr.io/htazq/tg-signer:latest` | 基础版，仅 CLI | `docker pull ghcr.io/htazq/tg-signer:latest` |
+| `ghcr.io/htazq/tg-signer:latest-webui` | WebUI 版 | `docker pull ghcr.io/htazq/tg-signer:latest-webui` |
+
+**支持的平台**: `linux/amd64`, `linux/arm64`
+
+**版本标签**:
+- `latest` / `latest-webui` - 最新稳定版
+- `v0.8.4` / `v0.8.4-webui` - 指定版本
+- `dev` / `dev-webui` - 开发版本
+
+---
+
+## 🚀 快速开始
+
+### 方式一: 使用 Docker Compose (推荐)
+
+1. **创建数据目录并进入 docker 目录**:
+   ```bash
+   cd docker
+   mkdir -p data
+   ```
+
+2. **启动 WebUI**:
+   ```bash
+   # 设置访问密码 (可选但强烈建议)
+   export AUTH_CODE="your_secure_password"
+   
+   # 启动
+   docker compose up -d webui
+   ```
+
+3. **访问 WebUI**: 打开浏览器访问 `http://localhost:8080`
+
+4. **在 WebUI 中完成**:
+   - 登录 Telegram 账号
+   - 配置签到任务或监控任务
+   - 设置定时运行
+
+### 方式二: 直接使用 Docker
+
+```bash
+# 创建数据目录
+mkdir -p data
+
+# 启动 WebUI
+docker run -d \
+  --name tg-signer-webui \
+  -p 8080:8080 \
+  -v $(pwd)/data:/opt/tg-signer \
+  -e TG_SIGNER_GUI_AUTHCODE=your_password \
+  -e TZ=Asia/Shanghai \
+  ghcr.io/htazq/tg-signer:latest-webui
 ```
 
-## 使用Dockerfile
+### 方式三: CLI 交互模式
 
-* ### 构建镜像：
+```bash
+# 启动容器进入交互模式
+docker run -it --rm \
+  -v $(pwd)/data:/opt/tg-signer \
+  -e TZ=Asia/Shanghai \
+  ghcr.io/htazq/tg-signer:latest \
+  bash
 
-    ```sh
-    docker build -t tg-signer:latest -f CN.Dockerfile .
-    ```
-
-* ### 运行
-
-    ```sh
-    docker run -d --name tg-signer --volume $PWD:/opt/tg-signer --env TG_PROXY=socks5://172.17.0.1:7890 tg-signer:latest bash start.sh
-    ```
-
-* ### 指定时区
-
-    构建镜像时可以通过 `TZ` 参数指定时区，例如：
-
-    ```sh
-    docker build --build-arg TZ=Europe/Paris -t tg-signer:latest -f CN.Dockerfile .
-    ```
-
-    运行容器时再次设置环境变量确保 `TZ` 传递进去（默认值 `Asia/Shanghai`）：
-
-    ```sh
-    docker run -d --name tg-signer \
-      --volume $PWD:/opt/tg-signer \
-      --env TG_PROXY=socks5://172.17.0.1:7890 \
-      --env TZ=Europe/Paris \
-      tg-signer:latest bash start.sh
-    ```
-
-## 或使用Docker Compose
-
-```sh
-docker-compose up -d
+# 在容器内执行
+tg-signer login           # 登录
+tg-signer run my_task     # 配置并运行签到
+tg-signer monitor run     # 配置并运行监控
 ```
 
-### 可选：调整时区
+---
 
-通过 `TZ` 环境变量可以在启动和构建期间一致地设置时区（默认 `Asia/Shanghai`）。示例：
+## ⚙️ 环境变量
 
-```sh
-TZ=Europe/Paris docker compose up -d
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `TZ` | 时区 | `Asia/Shanghai` |
+| `TG_PROXY` | 代理地址 | 无 |
+| `TG_ACCOUNT` | 账号名称 | `my_account` |
+| `TG_SIGNER_GUI_AUTHCODE` | WebUI 访问密码 | 无 (建议设置) |
+| `TG_SESSION_STRING` | Session 字符串 | 无 |
+
+### 代理设置
+
+如果需要通过代理访问 Telegram:
+
+```bash
+# 使用宿主机代理 (Docker Desktop)
+export TG_PROXY=socks5://host.docker.internal:7890
+
+# 使用宿主机代理 (Linux)
+export TG_PROXY=socks5://172.17.0.1:7890
+
+# 使用其他代理服务器
+export TG_PROXY=socks5://your-proxy:1080
 ```
 
-如果需要重新构建镜像以更新时区（例如从 `docker compose build`），也可以加上同样的 `TZ` 环境变量：
+---
 
-```sh
-TZ=Europe/Paris docker compose build
+## 🔧 本地构建
+
+### 构建基础镜像
+
+```bash
+# 国际网络
+docker build -t tg-signer:latest -f Dockerfile ..
+
+# 中国网络 (使用镜像加速)
+docker build -t tg-signer:latest -f CN.Dockerfile ..
 ```
 
-## 配置任务
+### 构建 WebUI 镜像
 
-接下来即可执行 `docker exec -it tg-signer bash` 进入容器进行登录和配置任务操作，见 [README.md](/README.md)。
+```bash
+docker build -t tg-signer:webui -f Dockerfile.webui ..
+```
+
+### 指定时区构建
+
+```bash
+docker build --build-arg TZ=Europe/Paris -t tg-signer:latest -f Dockerfile ..
+```
+
+---
+
+## 📁 目录结构
+
+```
+docker/
+├── Dockerfile           # 基础镜像
+├── Dockerfile.webui     # WebUI 镜像
+├── CN.Dockerfile        # 中国镜像加速版
+├── docker-compose.yml   # 标准 Compose 配置
+├── docker-compose.example.yml  # 完整配置示例
+└── README.md            # 本文档
+```
+
+挂载的数据目录结构:
+```
+data/
+├── my_account.session   # Telegram session 文件
+├── .signer/             # 配置和记录目录
+│   ├── signs/           # 签到任务
+│   ├── monitors/        # 监控任务
+│   └── ...
+└── logs/                # 日志目录
+```
+
+---
+
+## 📋 Docker Compose 完整示例
+
+参考 `docker-compose.example.yml` 获取包含以下服务的完整配置:
+
+- **webui**: WebUI 管理界面 (端口 8080)
+- **signer**: 后台签到服务
+- **monitor**: 消息监控服务
+
+使用示例:
+```bash
+# 复制示例配置
+cp docker-compose.example.yml docker-compose.yml
+
+# 编辑配置
+vim docker-compose.yml
+
+# 启动 WebUI
+docker compose up -d webui
+
+# 查看日志
+docker compose logs -f
+
+# 启动监控服务 (需要先取消 profiles)
+docker compose --profile monitor up -d
+```
+
+---
+
+## 🔄 更新镜像
+
+```bash
+# 拉取最新镜像
+docker compose pull
+
+# 重新创建容器
+docker compose up -d
+```
+
+---
+
+## 🐛 常见问题
+
+### 1. 无法连接 Telegram
+
+检查代理配置是否正确:
+```bash
+docker exec -it tg-signer-webui bash
+# 在容器内测试
+curl -x $TG_PROXY https://api.telegram.org
+```
+
+### 2. Session 失效
+
+删除旧的 session 文件重新登录:
+```bash
+rm data/*.session
+docker compose restart webui
+```
+
+### 3. 查看日志
+
+```bash
+# 查看容器日志
+docker compose logs -f webui
+
+# 查看应用日志
+cat data/logs/tg-signer.log
+```
+
+### 4. 进入容器调试
+
+```bash
+docker exec -it tg-signer-webui bash
+```
+
+---
+
+## 🔗 相关链接
+
+- [主项目文档](../README.md)
+- [GitHub 仓库](https://github.com/htazq/tg-signer)
+- [原作者仓库](https://github.com/amchii/tg-signer)

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -1,0 +1,93 @@
+# Docker Compose 完整使用示例
+# 复制此文件为 docker-compose.yml 并根据需要修改配置
+#
+# 使用方法:
+#   docker compose up -d           # 启动所有服务
+#   docker compose up -d webui     # 仅启动 WebUI
+#   docker compose up -d signer    # 仅启动签到服务
+#   docker compose logs -f         # 查看日志
+
+networks:
+  tg_network:
+    driver: bridge
+
+volumes:
+  signer_data:
+    driver: local
+
+services:
+  # ============================================
+  # WebUI 服务 - 通过浏览器管理 tg-signer
+  # ============================================
+  webui:
+    image: ghcr.io/htazq/tg-signer:latest-webui
+    container_name: tg-signer-webui
+    ports:
+      - "8080:8080"
+    volumes:
+      # 数据持久化目录
+      - ./data:/opt/tg-signer
+      # 或使用 Docker volume
+      # - signer_data:/opt/tg-signer
+    environment:
+      # 时区设置
+      - TZ=${TZ:-Asia/Shanghai}
+      # 代理设置 (如需要)
+      - TG_PROXY=${TG_PROXY:-}
+      # WebUI 访问密码 (强烈建议设置)
+      - TG_SIGNER_GUI_AUTHCODE=${AUTH_CODE:-your_secure_password}
+      # 账号名称
+      - TG_ACCOUNT=${TG_ACCOUNT:-my_account}
+    networks:
+      - tg_network
+    restart: unless-stopped
+    # 健康检查
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # ============================================
+  # 签到服务 - 后台运行签到任务
+  # ============================================
+  signer:
+    image: ghcr.io/htazq/tg-signer:latest
+    container_name: tg-signer
+    volumes:
+      # 与 WebUI 共享数据目录
+      - ./data:/opt/tg-signer
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - TG_PROXY=${TG_PROXY:-}
+      - TG_ACCOUNT=${TG_ACCOUNT:-my_account}
+    networks:
+      - tg_network
+    restart: unless-stopped
+    # 启动命令 - 根据你的任务名修改
+    # 首次使用请先通过 WebUI 或 CLI 完成登录和配置
+    command: ["tg-signer", "run", "my_task"]
+    # 如需交互式配置，可使用:
+    # command: ["sleep", "infinity"]
+    # 然后执行: docker exec -it tg-signer bash
+
+  # ============================================
+  # 监控服务 - 运行消息监控
+  # ============================================
+  monitor:
+    image: ghcr.io/htazq/tg-signer:latest
+    container_name: tg-signer-monitor
+    volumes:
+      - ./data:/opt/tg-signer
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - TG_PROXY=${TG_PROXY:-}
+      - TG_ACCOUNT=${TG_ACCOUNT:-my_account}
+    networks:
+      - tg_network
+    restart: unless-stopped
+    command: ["tg-signer", "monitor", "run", "my_monitor"]
+    # 默认不启动，需要时手动启用
+    profiles:
+      - monitor

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,5 +21,6 @@ services:
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - TG_PROXY=${TG_PROXY:-}
-      - TG_SIGNER_GUI_AUTHCODE=${AUTH_CODE:-}
+      # WebUI 访问密码，请修改为你自己的密码
+      - TG_SIGNER_GUI_AUTHCODE=change_me_to_your_password
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,21 +1,59 @@
+# tg-signer Docker Compose 配置
+# 使用方法:
+#   docker compose up -d           # 启动所有服务
+#   docker compose up -d webui     # 仅启动 WebUI
+#
+# 更完整的示例请参考 docker-compose.example.yml
+
 networks:
-  tg_host:
-    external: false
+  tg_network:
+    driver: bridge
 
 services:
-  tg-signer:
+  # ============================================
+  # WebUI 服务 - 推荐方式
+  # ============================================
+  webui:
+    # 使用预构建镜像 (推荐)
+    image: ghcr.io/htazq/tg-signer:latest-webui
+    # 或本地构建
+    # build:
+    #   context: ..
+    #   dockerfile: docker/Dockerfile.webui
+    #   args:
+    #     TZ: ${TZ:-Asia/Shanghai}
+    container_name: tg-signer-webui
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/opt/tg-signer
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - TG_PROXY=${TG_PROXY:-}
+      - TG_SIGNER_GUI_AUTHCODE=${AUTH_CODE:-}
+    networks:
+      - tg_network
+    restart: unless-stopped
+
+  # ============================================
+  # 签到服务 - 本地构建方式 (中国镜像加速)
+  # ============================================
+  signer:
     build:
-      context: .
-      dockerfile: CN.Dockerfile
+      context: ..
+      dockerfile: docker/CN.Dockerfile
       args:
         TZ: ${TZ:-Asia/Shanghai}
     container_name: tg-signer
     command: ["/bin/bash", "start.sh"]
     volumes:
-      - $PWD:/opt/tg-signer
+      - ./data:/opt/tg-signer
     environment:
-      - TG_PROXY=socks5://172.17.0.1:7890
+      - TG_PROXY=${TG_PROXY:-socks5://172.17.0.1:7890}
       - TZ=${TZ:-Asia/Shanghai}
     networks:
-      - tg_host
+      - tg_network
     restart: unless-stopped
+    # 默认不启动，根据需要启用
+    profiles:
+      - cli

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,28 +1,19 @@
 # tg-signer Docker Compose 配置
-# 使用方法:
-#   docker compose up -d           # 启动所有服务
-#   docker compose up -d webui     # 仅启动 WebUI
 #
-# 更完整的示例请参考 docker-compose.example.yml
-
-networks:
-  tg_network:
-    driver: bridge
+# 使用方法:
+#   1. 创建数据目录: mkdir -p data
+#   2. 启动: docker compose up -d
+#   3. 访问: http://localhost:8080
+#
+# 环境变量 (可选):
+#   - AUTH_CODE: WebUI 访问密码
+#   - TG_PROXY: 代理地址 (如 socks5://host.docker.internal:7890)
+#   - TZ: 时区 (默认 Asia/Shanghai)
 
 services:
-  # ============================================
-  # WebUI 服务 - 推荐方式
-  # ============================================
-  webui:
-    # 使用预构建镜像 (推荐)
+  tg-signer:
     image: ghcr.io/htazq/tg-signer:latest-webui
-    # 或本地构建
-    # build:
-    #   context: ..
-    #   dockerfile: docker/Dockerfile.webui
-    #   args:
-    #     TZ: ${TZ:-Asia/Shanghai}
-    container_name: tg-signer-webui
+    container_name: tg-signer
     ports:
       - "8080:8080"
     volumes:
@@ -31,29 +22,4 @@ services:
       - TZ=${TZ:-Asia/Shanghai}
       - TG_PROXY=${TG_PROXY:-}
       - TG_SIGNER_GUI_AUTHCODE=${AUTH_CODE:-}
-    networks:
-      - tg_network
     restart: unless-stopped
-
-  # ============================================
-  # 签到服务 - 本地构建方式 (中国镜像加速)
-  # ============================================
-  signer:
-    build:
-      context: ..
-      dockerfile: docker/CN.Dockerfile
-      args:
-        TZ: ${TZ:-Asia/Shanghai}
-    container_name: tg-signer
-    command: ["/bin/bash", "start.sh"]
-    volumes:
-      - ./data:/opt/tg-signer
-    environment:
-      - TG_PROXY=${TG_PROXY:-socks5://172.17.0.1:7890}
-      - TZ=${TZ:-Asia/Shanghai}
-    networks:
-      - tg_network
-    restart: unless-stopped
-    # 默认不启动，根据需要启用
-    profiles:
-      - cli

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,26 +1,24 @@
 # tg-signer Docker Compose 配置
 #
-# 使用方法:
-#   1. 创建数据目录: mkdir -p data
-#   2. 启动: docker compose up -d
-#   3. 访问: http://localhost:8080
-#
-# 环境变量 (可选):
-#   - AUTH_CODE: WebUI 访问密码
-#   - TG_PROXY: 代理地址 (如 socks5://host.docker.internal:7890)
-#   - TZ: 时区 (默认 Asia/Shanghai)
+# 首次使用请按以下步骤操作：
+#   1. 启动容器: docker compose up -d
+#   2. 进入容器: docker exec -it tg-signer bash
+#   3. 登录 TG: tg-signer login
+#   4. 配置任务: tg-signer run my_task (按提示配置)
+#   5. 退出容器后，修改下方 command 为实际任务名
+#   6. 重启容器: docker compose up -d
 
 services:
   tg-signer:
-    image: ghcr.io/htazq/tg-signer:latest-webui
+    image: ghcr.io/htazq/tg-signer:latest
     container_name: tg-signer
-    ports:
-      - "8080:8080"
     volumes:
       - ./data:/opt/tg-signer
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - TG_PROXY=${TG_PROXY:-}
-      # WebUI 访问密码，请修改为你自己的密码
-      - TG_SIGNER_GUI_AUTHCODE=change_me_to_your_password
     restart: unless-stopped
+    # 首次配置时使用 sleep infinity 保持容器运行
+    command: ["sleep", "infinity"]
+    # 配置完成后，改为运行任务（取消下行注释，注释上行）
+    # command: ["tg-signer", "run", "任务名1", "任务名2"]


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow for automated Docker image builds with multi-platform support (amd64/arm64).

## Changes
- Add [.github/workflows/docker-build.yml](cci:7://file:///c:/Users/60977/Documents/code/py/git/tg-signer/.github/workflows/docker-build.yml:0:0-0:0) - Multi-platform Docker build workflow
- Add [docker/Dockerfile.webui](cci:7://file:///c:/Users/60977/Documents/code/py/git/tg-signer/docker/Dockerfile.webui:0:0-0:0) - WebUI Docker image with nicegui support  
- Add [docker/docker-compose.example.yml](cci:7://file:///c:/Users/60977/Documents/code/py/git/tg-signer/docker/docker-compose.example.yml:0:0-0:0) - Complete docker-compose example
- Update [docker/docker-compose.yml](cci:7://file:///c:/Users/60977/Documents/code/py/git/tg-signer/docker/docker-compose.yml:0:0-0:0) - Simplified for easy usage
- Update [docker/README.md](cci:7://file:///c:/Users/60977/Documents/code/py/git/tg-signer/docker/README.md:0:0-0:0) - Concise usage guide

## Docker Images
After merging, images will be published to GitHub Container Registry:
- `ghcr.io/amchii/tg-signer:latest` (CLI only)
- `ghcr.io/amchii/tg-signer:latest-webui` (CLI + WebUI)

## Quick Start
```bash
mkdir -p data && cd data
curl -O [https://raw.githubusercontent.com/amchii/tg-signer/main/docker/docker-compose.yml](https://raw.githubusercontent.com/amchii/tg-signer/main/docker/docker-compose.yml)
docker compose up -d
# Visit http://localhost:8080