### PR TITLE
feat: publish official Docker images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,78 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - target: cli
+            tag_suffix: ''
+            latest_tag: latest
+          - target: webui
+            tag_suffix: -webui
+            latest_tag: latest-webui
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare image tags
+        id: prep
+        shell: bash
+        run: |
+          ref_name="${GITHUB_REF_NAME}"
+          image="${REGISTRY}/${IMAGE_NAME}"
+
+          {
+            echo "tags<<EOF"
+            echo "${image}:${ref_name}${{ matrix.tag_suffix }}"
+            if [[ "${ref_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "${image}:${{ matrix.latest_tag }}"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build and push ${{ matrix.target }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/GHCR.Dockerfile
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=tg-signer
+            org.opencontainers.image.description=Automated Telegram tasks with check-ins, monitoring, forwarding, and auto replies.
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}${{ matrix.tag_suffix }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build
+        required: true
+        default: main
+      image_tag:
+        description: Docker image tag to publish for this manual run
+        required: true
+        default: manual-test
 
 env:
   REGISTRY: ghcr.io
@@ -28,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -45,14 +57,29 @@ jobs:
       - name: Prepare image tags
         id: prep
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_TAG_NAME: ${{ github.ref_name }}
+          MANUAL_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          ref_name="${GITHUB_REF_NAME}"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            ref_name="${MANUAL_IMAGE_TAG}"
+          else
+            ref_name="${PUSH_TAG_NAME}"
+          fi
+
           image="${REGISTRY}/${IMAGE_NAME}"
 
+          if [[ ! "${ref_name}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Unsupported Docker tag format: ${ref_name}" >&2
+            exit 1
+          fi
+
           {
+            echo "version_tag=${ref_name}${{ matrix.tag_suffix }}"
             echo "tags<<EOF"
             echo "${image}:${ref_name}${{ matrix.tag_suffix }}"
-            if [[ "${ref_name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [[ "${EVENT_NAME}" == "push" ]]; then
               echo "${image}:${{ matrix.latest_tag }}"
             fi
             echo "EOF"
@@ -73,6 +100,6 @@ jobs:
             org.opencontainers.image.description=Automated Telegram tasks with check-ins, monitoring, forwarding, and auto replies.
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.ref_name }}${{ matrix.tag_suffix }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install "tg-signer[gui]"
 
 ### Docker
 
-官方会在 GitHub Container Registry 提供两种预构建镜像：`ghcr.io/amchii/tg-signer:<tag>`（CLI，包含 `speedup/tgcrypto`）和 `ghcr.io/amchii/tg-signer:<tag>-webui`（CLI + WebUI）。稳定版 release 会额外同步 `latest` 与 `latest-webui` 标签。  
+官方会在 GitHub Container Registry 提供两种预构建镜像：`ghcr.io/amchii/tg-signer:<tag>`（CLI，包含 `speedup/tgcrypto`）和 `ghcr.io/amchii/tg-signer:<tag>-webui`（CLI + WebUI）。当推送合法 Docker tag 格式的 Git tag（例如 `v0.0.0`、`0.0.0`、`v0.0.0-beta`）时，会额外同步 `latest` 与 `latest-webui` 标签；也可以在 GitHub Actions 中手动触发 Docker 发布，仅推送指定测试 tag，不覆盖 `latest`。<br>
 如果需要自行构建镜像，本地 build 方式仍然保留，见 [docker](./docker) 目录下的 Dockerfile 和 [README](./docker/README.md) 。
 
 ### 使用方法

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ pip install "tg-signer[gui]"
 
 ### Docker
 
-未上传直接使用的镜像，可以自行build镜像，见 [docker](./docker) 目录下的Dockerfile和 [README](./docker/README.md) 。
+官方会在 GitHub Container Registry 提供两种预构建镜像：`ghcr.io/amchii/tg-signer:<tag>`（CLI，包含 `speedup/tgcrypto`）和 `ghcr.io/amchii/tg-signer:<tag>-webui`（CLI + WebUI）。稳定版 release 会额外同步 `latest` 与 `latest-webui` 标签。  
+如果需要自行构建镜像，本地 build 方式仍然保留，见 [docker](./docker) 目录下的 Dockerfile 和 [README](./docker/README.md) 。
 
 ### 使用方法
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -28,7 +28,7 @@ pip install "tg-signer[speedup]"
 
 #### Docker
 
-Official images are published to GitHub Container Registry in two variants: `ghcr.io/amchii/tg-signer:<tag>` (CLI, including `speedup/tgcrypto`) and `ghcr.io/amchii/tg-signer:<tag>-webui` (CLI + WebUI). Stable releases also update the `latest` and `latest-webui` tags.
+Official images are published to GitHub Container Registry in two variants: `ghcr.io/amchii/tg-signer:<tag>` (CLI, including `speedup/tgcrypto`) and `ghcr.io/amchii/tg-signer:<tag>-webui` (CLI + WebUI). Pushing a Git tag that is valid as a Docker tag, such as `v0.0.0`, `0.0.0`, or `v0.0.0-beta`, also updates the `latest` and `latest-webui` tags; you can also trigger the Docker publish workflow manually in GitHub Actions to push only a custom test tag without overwriting `latest`.
 If you prefer to build locally, the existing Dockerfiles and local build flow remain available in the [docker](./docker) directory and its [README](./docker/README.md).
 
 ### Usage

--- a/README_EN.md
+++ b/README_EN.md
@@ -28,7 +28,8 @@ pip install "tg-signer[speedup]"
 
 #### Docker
 
-No pre-built image is provided. You can build your own image using the Dockerfile and [README](./docker/README.md) in the [docker](./docker) directory.
+Official images are published to GitHub Container Registry in two variants: `ghcr.io/amchii/tg-signer:<tag>` (CLI, including `speedup/tgcrypto`) and `ghcr.io/amchii/tg-signer:<tag>-webui` (CLI + WebUI). Stable releases also update the `latest` and `latest-webui` tags.
+If you prefer to build locally, the existing Dockerfiles and local build flow remain available in the [docker](./docker) directory and its [README](./docker/README.md).
 
 ### Usage
 

--- a/docker/CN.Dockerfile
+++ b/docker/CN.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y gcc && \
     mkdir -p build && \
     pip wheel -w build tgcrypto
 
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 ARG TZ=Asia/Shanghai
 ENV TZ=${TZ}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y gcc && \
     mkdir -p build && \
     pip wheel -w build tgcrypto
 
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 ARG TZ=Asia/Shanghai
 ENV TZ=${TZ}

--- a/docker/GHCR.Dockerfile
+++ b/docker/GHCR.Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm AS builder
 
 WORKDIR /build
 
-RUN apt-get update && apt-get install -y --no-install-recommends gcc && \
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml README.md ./

--- a/docker/GHCR.Dockerfile
+++ b/docker/GHCR.Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.12-slim-bookworm AS builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./
+COPY tg_signer ./tg_signer
+
+RUN mkdir -p dist && \
+    pip wheel --wheel-dir dist tgcrypto && \
+    pip wheel --no-deps --wheel-dir dist .
+
+FROM python:3.12-slim AS cli
+
+ARG TZ=Asia/Shanghai
+ENV TZ=${TZ}
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=builder /build/dist/*.whl /tmp/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata && \
+    ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    echo ${TZ} > /etc/timezone && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir /tmp/*.whl && \
+    rm -rf /tmp/*.whl
+
+WORKDIR /opt/tg-signer
+
+FROM cli AS webui
+
+RUN pip install --no-cache-dir nicegui
+
+EXPOSE 8080
+
+CMD ["tg-signer", "webgui", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/GHCR.Dockerfile
+++ b/docker/GHCR.Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p dist && \
     pip wheel --wheel-dir dist tgcrypto && \
     pip wheel --no-deps --wheel-dir dist .
 
-FROM python:3.12-slim AS cli
+FROM python:3.12-slim-bookworm AS cli
 
 ARG TZ=Asia/Shanghai
 ENV TZ=${TZ}

--- a/docker/GHCR.Dockerfile
+++ b/docker/GHCR.Dockerfile
@@ -5,12 +5,8 @@ WORKDIR /build
 RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
     rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml README.md ./
-COPY tg_signer ./tg_signer
-
 RUN mkdir -p dist && \
-    pip wheel --wheel-dir dist tgcrypto && \
-    pip wheel --no-deps --wheel-dir dist .
+    pip wheel --wheel-dir dist tgcrypto
 
 FROM python:3.12-slim-bookworm AS cli
 
@@ -19,6 +15,9 @@ ENV TZ=${TZ}
 ENV DEBIAN_FRONTEND=noninteractive
 
 COPY --from=builder /build/dist/*.whl /tmp/
+WORKDIR /tmp/tg-signer-src
+COPY pyproject.toml README.md ./
+COPY tg_signer ./tg_signer
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends tzdata && \
@@ -27,14 +26,22 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir /tmp/*.whl && \
-    rm -rf /tmp/*.whl
+    pip install --no-cache-dir . && \
+    cd / && rm -rf /tmp/*.whl /tmp/tg-signer-src
 
 WORKDIR /opt/tg-signer
 
 FROM cli AS webui
 
-RUN pip install --no-cache-dir nicegui
+WORKDIR /tmp/tg-signer-src
+COPY pyproject.toml README.md ./
+COPY tg_signer ./tg_signer
+
+RUN pip install --no-cache-dir ".[gui]" && \
+    cd / && rm -rf /tmp/tg-signer-src
 
 EXPOSE 8080
+
+WORKDIR /opt/tg-signer
 
 CMD ["tg-signer", "webgui", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,12 +17,21 @@ sleep infinity
 发布版本会同步到 GitHub Container Registry：
 
 - `ghcr.io/amchii/tg-signer:<tag>`
-- `ghcr.io/amchii/tg-signer:latest`（仅稳定版 release 更新）
+- `ghcr.io/amchii/tg-signer:latest`（当推送合法 Docker tag 格式的 Git tag，例如 `v0.0.0`、`0.0.0`、`v0.0.0-beta` 时更新）
 - `ghcr.io/amchii/tg-signer:<tag>-webui`
-- `ghcr.io/amchii/tg-signer:latest-webui`（仅稳定版 release 更新）
+- `ghcr.io/amchii/tg-signer:latest-webui`（当推送合法 Docker tag 格式的 Git tag，例如 `v0.0.0`、`0.0.0`、`v0.0.0-beta` 时更新）
 
-其中基础镜像默认包含 `speedup` 所需的 `tgcrypto`，`-webui` 变体会额外安装 `nicegui` 并默认监听 `8080` 端口。
+其中基础镜像默认包含 `speedup` 所需的 `tgcrypto`，`-webui` 变体会额外安装 `gui` 额外依赖（当前包含 `nicegui`）并默认监听 `8080` 端口。
 如果你需要使用国内镜像源或调整构建参数，仍然可以继续按下文方式在本地构建。
+
+### 手动测试推送
+
+如果你只想测试 Docker 镜像，而不想因为推送 Git tag 触发 PyPI 发布，可以在 GitHub Actions 中手动运行 `Publish Docker Image` workflow：
+
+- `ref`：要构建的分支、提交或 tag
+- `image_tag`：本次测试镜像要推送到 GHCR 的 tag，例如 `manual-test`、`pr-123`、`sha-abcdef`
+
+手动触发时只会推送你指定的测试 tag 和对应的 `-webui` tag，不会覆盖 `latest` 与 `latest-webui`。
 
 ### 直接运行预构建镜像
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,39 @@ sleep infinity
 # tg-signer run mytasks
 ```
 
+## 使用预构建镜像
+
+发布版本会同步到 GitHub Container Registry：
+
+- `ghcr.io/amchii/tg-signer:<tag>`
+- `ghcr.io/amchii/tg-signer:latest`（仅稳定版 release 更新）
+- `ghcr.io/amchii/tg-signer:<tag>-webui`
+- `ghcr.io/amchii/tg-signer:latest-webui`（仅稳定版 release 更新）
+
+其中基础镜像默认包含 `speedup` 所需的 `tgcrypto`，`-webui` 变体会额外安装 `nicegui` 并默认监听 `8080` 端口。
+如果你需要使用国内镜像源或调整构建参数，仍然可以继续按下文方式在本地构建。
+
+### 直接运行预构建镜像
+
+CLI 镜像示例：
+
+```sh
+docker run -d --name tg-signer \
+  --volume $PWD:/opt/tg-signer \
+  --env TG_PROXY=socks5://172.17.0.1:7890 \
+  ghcr.io/amchii/tg-signer:latest bash start.sh
+```
+
+WebUI 镜像示例：
+
+```sh
+docker run -d --name tg-signer-webui \
+  --volume $PWD:/opt/tg-signer \
+  --publish 8080:8080 \
+  --env TG_SIGNER_GUI_AUTHCODE=change-me \
+  ghcr.io/amchii/tg-signer:latest-webui
+```
+
 ## 使用Dockerfile
 
 * ### 构建镜像：


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to publish official Docker images to GitHub Container Registry
- publish both CLI and WebUI image variants from CI
- keep the existing local Docker build flow unchanged
- document the new image tags and direct usage examples

## What changed
- added `.github/workflows/docker-publish.yml` to build and push multi-arch images on tag pushes
- added `docker/GHCR.Dockerfile` as a CI-focused Dockerfile that builds from the current repository source
- kept the local Dockerfiles intact so local builds still work as before
- updated the Docker docs in `README.md`, `README_EN.md`, and `docker/README.md`

## Image tags
- `ghcr.io/amchii/tg-signer:<tag>`
- `ghcr.io/amchii/tg-signer:latest` for stable releases only
- `ghcr.io/amchii/tg-signer:<tag>-webui`
- `ghcr.io/amchii/tg-signer:latest-webui` for stable releases only

## Notes
- the base image includes `speedup` support by installing `tgcrypto`
- the `-webui` image extends the base image and adds `nicegui`
- stable tags update `latest` and `latest-webui`, while pre-release tags only publish versioned tags
