### PR TITLE
fix: support @username chat ids in signer configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ tg-signer run-once my_sign  # 直接运行一次'my_sign'任务
 tg-signer list-sign-records linuxdo -n 5  # 查看任务 linuxdo 最近 5 条签到记录
 tg-signer migrate-sign-records  # 将.signer/signs 下的签到记录迁移到 SQLite
 tg-signer send-text 8671234001 /test  # 向chat_id为'8671234001'的聊天发送'/test'文本
+tg-signer send-text @neo /test  # 向username为'@neo'的聊天发送'/test'文本
 tg-signer send-text --message-thread-id 1 -- -1003763902761 checkin  # 发送到群组话题(message_thread_id=1)
 tg-signer send-text -- -10006758812 浇水  # 对于负数需要使用POSIX风格，在短横线'-'前方加上'--'
 tg-signer send-text --delete-after 1 8671234001 /test  # 向chat_id为'8671234001'的聊天发送'/test'文本, 并在1秒后删除发送的消息
@@ -136,6 +137,7 @@ tg-signer login
 ```
 
 根据提示输入手机号码和验证码进行登录并获取最近的聊天列表，确保你想要签到的聊天在列表内。
+签到任务里的`chat_id`同时支持整数ID和以`@`开头的username，例如`@neo`。
 对于论坛群组，登录输出中会额外打印每个话题的 `message_thread_id`，可直接用于 `--message-thread-id`。
 
 ### 获取群组话题 ID
@@ -150,6 +152,7 @@ tg-signer list-topics --chat_id -1003763902761
 
 ```sh
 tg-signer send-text 8671234001 hello  # 向chat_id为'8671234001'的聊天发送'hello'文本
+tg-signer send-text @neo hello  # 向username为'@neo'的聊天发送'hello'文本
 ```
 
 ### 运行签到任务
@@ -171,7 +174,7 @@ tg-signer run linuxdo
 ```
 开始配置任务<linuxdo>
 第1个签到
-一. Chat ID（登录时最近对话输出中的ID）: 7661096533
+一. Chat ID（登录时最近对话输出中的ID或@username）: 7661096533
 二. Chat名称（可选）: jerry bot
 三. 是否发送到话题（message_thread_id）？(y/N)：y
 四. message_thread_id: 1

--- a/README_EN.md
+++ b/README_EN.md
@@ -124,6 +124,7 @@ tg-signer run-once my_sign  # Run the 'my_sign' task once directly
 tg-signer list-sign-records linuxdo -n 5  # View the latest 5 check-in records for task linuxdo
 tg-signer migrate-sign-records  # Migrate check-in records under .signer/signs to SQLite
 tg-signer send-text 8671234001 /test  # Send '/test' to chat_id '8671234001'
+tg-signer send-text @neo /test  # Send '/test' to username '@neo'
 tg-signer send-text --message-thread-id 1 -- -1003763902761 checkin  # Send to a group topic (message_thread_id=1)
 tg-signer send-text -- -10006758812 water  # For negative numbers, use POSIX style and add '--' before '-'
 tg-signer send-text --delete-after 1 8671234001 /test  # Send '/test' to chat_id '8671234001' and delete it after 1 second
@@ -157,6 +158,9 @@ Follow the prompts to enter your phone number and verification code. The command
 will print your recent chats, so make sure the chat you want to use for
 check-ins is included.
 
+Signer `chat_id` also supports integer IDs and `@`-prefixed usernames such as
+`@neo`.
+
 For forum-style groups, the login output also prints each topic's
 `message_thread_id`, which can be used directly with `--message-thread-id`.
 
@@ -174,6 +178,7 @@ much easier.
 
 ```sh
 tg-signer send-text 8671234001 hello  # Send 'hello' to chat_id '8671234001'
+tg-signer send-text @neo hello  # Send 'hello' to username '@neo'
 ```
 
 ### Run a Check-in Task
@@ -195,7 +200,7 @@ Then follow the prompts to configure it.
 ```text
 Start configuring task <linuxdo>
 Check-in 1
-1. Chat ID (the ID shown in the recent chats output during login): 7661096533
+1. Chat ID (from recent chats during login or @username): 7661096533
 2. Chat name (optional): jerry bot
 3. Send to a topic (`message_thread_id`)? (y/N): y
 4. message_thread_id: 1

--- a/tests/test_cli_signer_message_thread_id.py
+++ b/tests/test_cli_signer_message_thread_id.py
@@ -112,6 +112,17 @@ def test_send_text_supports_message_thread_id(dummy_signer, runner):
     assert dummy_signer.calls[0]["message_thread_id"] == 1
 
 
+def test_send_text_accepts_username_chat_id(dummy_signer, runner):
+    result = runner.invoke(
+        signer_cli.tg_signer,
+        ["send-text", "@neo", "checkin"],
+    )
+
+    assert result.exit_code == 0
+    assert dummy_signer.calls[0]["method"] == "send_text"
+    assert dummy_signer.calls[0]["chat_id"] == "@neo"
+
+
 def test_send_dice_supports_message_thread_id(dummy_signer, runner):
     result = runner.invoke(
         signer_cli.tg_signer,
@@ -121,6 +132,17 @@ def test_send_dice_supports_message_thread_id(dummy_signer, runner):
     assert result.exit_code == 0
     assert dummy_signer.calls[0]["method"] == "send_dice_cli"
     assert dummy_signer.calls[0]["message_thread_id"] == 1
+
+
+def test_send_dice_accepts_username_chat_id(dummy_signer, runner):
+    result = runner.invoke(
+        signer_cli.tg_signer,
+        ["send-dice", "@neo", "🎲"],
+    )
+
+    assert result.exit_code == 0
+    assert dummy_signer.calls[0]["method"] == "send_dice_cli"
+    assert dummy_signer.calls[0]["chat_id"] == "@neo"
 
 
 def test_schedule_messages_supports_message_thread_id(dummy_signer, runner):
@@ -142,6 +164,34 @@ def test_schedule_messages_supports_message_thread_id(dummy_signer, runner):
     assert dummy_signer.calls[0]["message_thread_id"] == 1
 
 
+def test_schedule_messages_accepts_username_chat_id(dummy_signer, runner):
+    result = runner.invoke(
+        signer_cli.tg_signer,
+        [
+            "schedule-messages",
+            "--crontab",
+            "0 6 * * *",
+            "@neo",
+            "checkin",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert dummy_signer.calls[0]["method"] == "schedule_messages"
+    assert dummy_signer.calls[0]["chat_id"] == "@neo"
+
+
+def test_list_schedule_messages_accepts_username_chat_id(dummy_signer, runner):
+    result = runner.invoke(
+        signer_cli.tg_signer,
+        ["list-schedule-messages", "@neo"],
+    )
+
+    assert result.exit_code == 0
+    assert dummy_signer.calls[0]["method"] == "get_schedule_messages"
+    assert dummy_signer.calls[0]["chat_id"] == "@neo"
+
+
 def test_list_topics(dummy_signer, runner):
     result = runner.invoke(
         signer_cli.tg_signer,
@@ -152,3 +202,14 @@ def test_list_topics(dummy_signer, runner):
     assert dummy_signer.calls[0]["method"] == "list_topics"
     assert dummy_signer.calls[0]["chat_id"] == -1003763902761
     assert dummy_signer.calls[0]["limit"] == 50
+
+
+def test_list_topics_accepts_username_chat_id(dummy_signer, runner):
+    result = runner.invoke(
+        signer_cli.tg_signer,
+        ["list-topics", "--chat_id", "@neo", "--limit", "50"],
+    )
+
+    assert result.exit_code == 0
+    assert dummy_signer.calls[0]["method"] == "list_topics"
+    assert dummy_signer.calls[0]["chat_id"] == "@neo"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from tg_signer.config import SendTextAction, SignChatV3
+from tg_signer.config import ClickKeyboardByTextAction, SendTextAction, SignChatV3
 from tg_signer.core import (
     BaseUserWorker,
     ChatType,
@@ -791,6 +791,48 @@ async def test_wait_for_send_text_passes_message_thread_id(signer_factory):
 
 
 @pytest.mark.asyncio
+async def test_resolve_chat_route_key_supports_username(monkeypatch, signer_factory):
+    signer = signer_factory()
+    signer.context = signer.ensure_ctx()
+    chat = SignChatV3(
+        chat_id="@neo",
+        actions=[SendTextAction(text="checkin")],
+    )
+
+    async def fake_get_chat(chat_id):
+        assert chat_id == "@neo"
+        return SimpleNamespace(id=-1003763902761)
+
+    monkeypatch.setattr(signer.app, "get_chat", fake_get_chat)
+
+    route_key = await signer.resolve_chat_route_key(chat)
+
+    assert route_key == (-1003763902761, None)
+    assert signer.context.resolved_route_keys[("@neo", None)] == route_key
+
+
+@pytest.mark.asyncio
+async def test_wait_for_uses_resolved_route_key_for_username(signer_factory):
+    signer = signer_factory()
+    signer.context = signer.ensure_ctx()
+    chat = SignChatV3(
+        chat_id="@neo",
+        actions=[ClickKeyboardByTextAction(text="签到")],
+    )
+    raw_key = signer.get_route_key("@neo", None)
+    resolved_key = signer.get_route_key(-1003763902761, None)
+    message = SimpleNamespace(id=99, text="签到", photo=None, reply_markup=None)
+    signer.context.resolved_route_keys[raw_key] = resolved_key
+    signer.context.chat_messages[resolved_key][99] = message
+    signer._click_keyboard_by_text = AsyncMock(return_value=True)
+
+    await signer.wait_for(chat, chat.actions[0], timeout=0.5)
+
+    signer._click_keyboard_by_text.assert_awaited_once_with(chat.actions[0], message)
+    assert signer.context.chat_messages[resolved_key][99] is None
+
+
+@pytest.mark.asyncio
 async def test_on_message_routes_by_chat_id_and_message_thread_id(signer_factory):
     signer = signer_factory()
     signer.context = signer.ensure_ctx()
@@ -833,6 +875,28 @@ async def test_on_message_falls_back_to_non_thread_route(signer_factory):
     await signer._on_message(signer.app, message)
 
     assert signer.context.chat_messages[fallback_key][100] is message
+
+
+@pytest.mark.asyncio
+async def test_on_message_routes_username_chat_by_resolved_chat_id(signer_factory):
+    signer = signer_factory()
+    signer.context = signer.ensure_ctx()
+    resolved_key = signer.get_route_key(-1003763902761, None)
+    signer.context.sign_chats[resolved_key].append(
+        SignChatV3(
+            chat_id="@neo",
+            actions=[SendTextAction(text="checkin")],
+        )
+    )
+    message = SimpleNamespace(
+        chat=SimpleNamespace(id=-1003763902761),
+        message_thread_id=None,
+        id=101,
+    )
+
+    await signer._on_message(signer.app, message)
+
+    assert signer.context.chat_messages[resolved_key][101] is message
 
 
 @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from tg_signer.config import ClickKeyboardByTextAction, SendTextAction, SignChatV3
+from tg_signer.config import (
+    ClickKeyboardByTextAction,
+    SendTextAction,
+    SignChatV3,
+    SignConfigV3,
+)
 from tg_signer.core import (
     BaseUserWorker,
     ChatType,
@@ -975,3 +980,52 @@ async def test_get_schedule_messages_calls_chat_level_api(monkeypatch, signer_fa
     await signer.get_schedule_messages(-1003763902761)
 
     assert calls[0]["kwargs"] == {}
+
+
+def test_normal_run_skips_username_resolution_errors_per_chat(signer_factory):
+    import tg_signer.core as core
+
+    signer = signer_factory()
+    signer.user = SimpleNamespace(id=1)
+    signer.context = signer.ensure_ctx()
+    signer._validate_sign_at = lambda *_: "0 0 * * *"
+    signer.load_sign_record = lambda: {}
+    signer.persist_sign_record = lambda *_args, **_kwargs: None
+
+    config = SignConfigV3(
+        chats=[
+            SignChatV3(chat_id="@bad", actions=[SendTextAction(text="bad")]),
+            SignChatV3(chat_id=123456, actions=[SendTextAction(text="good")]),
+        ],
+        sign_at="0 0 * * *",
+        sign_interval=0,
+    )
+    signer.load_config = lambda _cls: config
+
+    signed_chats = []
+
+    async def fake_sign_a_chat(chat):
+        signed_chats.append(chat.chat_id)
+
+    signer.sign_a_chat = fake_sign_a_chat
+
+    class DummyApp:
+        key = "dummy-app"
+
+        def add_handler(self, *_args, **_kwargs):
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def get_chat(self, chat_id):
+            raise core.errors.UsernameNotOccupied(chat_id)
+
+    signer.app = DummyApp()
+
+    asyncio.run(signer.normal_run(only_once=True))
+
+    assert signed_chats == [123456]

--- a/tests/test_match_config.py
+++ b/tests/test_match_config.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from pydantic import ValidationError
 
 from tg_signer.config import MatchConfig
 
@@ -73,7 +74,9 @@ class TestMatchConfig:
     )
     def test_match_text(self, rule, rule_value, text, ignore_case, expected):
         # 构建 MatchConfig 实例
-        config = MatchConfig(rule=rule, rule_value=rule_value, ignore_case=ignore_case)
+        config = MatchConfig(
+            chat_id=123, rule=rule, rule_value=rule_value, ignore_case=ignore_case
+        )
         # 进行匹配测试
         assert config.match_text(text) == expected
 
@@ -133,7 +136,7 @@ class TestMatchConfig:
 
     def test_match_combines_chat_user_and_text(self):
         config = MatchConfig(
-            chat_id="target_chat",
+            chat_id="@target_chat",
             rule="contains",
             rule_value="hello",
             from_user_ids=["@alice"],
@@ -153,17 +156,23 @@ class TestMatchConfig:
 
         assert config.match_chat(message.chat) is True
 
-    def test_match_chat_returns_false_when_chat_id_is_none(self):
-        config = MatchConfig(rule="all")
-        message = make_message(chat_username="target_chat")
+    def test_match_config_rejects_missing_chat_id(self):
+        with pytest.raises(ValidationError):
+            MatchConfig(rule="all")
 
-        assert config.match_chat(message.chat) is False
+    def test_match_config_rejects_none_chat_id(self):
+        with pytest.raises(ValidationError):
+            MatchConfig(chat_id=None, rule="all")
 
     def test_match_config_coerces_numeric_string_chat_id_to_int(self):
         config = MatchConfig(chat_id="-1001234567890", rule="all")
 
         assert config.chat_id == -1001234567890
         assert isinstance(config.chat_id, int)
+
+    def test_match_config_rejects_username_without_at_prefix(self):
+        with pytest.raises(ValidationError):
+            MatchConfig(chat_id="target_chat", rule="all")
 
     def test_match_rejects_self_when_always_ignore_me_enabled(self):
         config = MatchConfig(

--- a/tests/test_match_config.py
+++ b/tests/test_match_config.py
@@ -147,6 +147,12 @@ class TestMatchConfig:
 
         assert config.match(message) is True
 
+    def test_match_chat_accepts_at_prefixed_username(self):
+        config = MatchConfig(chat_id="@Target_Chat", rule="all")
+        message = make_message(chat_username="target_chat")
+
+        assert config.match_chat(message.chat) is True
+
     def test_match_rejects_self_when_always_ignore_me_enabled(self):
         config = MatchConfig(
             chat_id=123,

--- a/tests/test_match_config.py
+++ b/tests/test_match_config.py
@@ -153,6 +153,18 @@ class TestMatchConfig:
 
         assert config.match_chat(message.chat) is True
 
+    def test_match_chat_returns_false_when_chat_id_is_none(self):
+        config = MatchConfig(rule="all")
+        message = make_message(chat_username="target_chat")
+
+        assert config.match_chat(message.chat) is False
+
+    def test_match_config_coerces_numeric_string_chat_id_to_int(self):
+        config = MatchConfig(chat_id="-1001234567890", rule="all")
+
+        assert config.chat_id == -1001234567890
+        assert isinstance(config.chat_id, int)
+
     def test_match_rejects_self_when_always_ignore_me_enabled(self):
         config = MatchConfig(
             chat_id=123,

--- a/tests/test_sign_config_v2_to_v3.py
+++ b/tests/test_sign_config_v2_to_v3.py
@@ -147,3 +147,11 @@ class TestSignConfigV2ToCurrent:
             actions=[SendTextAction(text="checkin")],
         )
         assert chat.message_thread_id == 1
+
+    def test_sign_chat_v3_supports_username_chat_id(self):
+        chat = SignChatV3(
+            chat_id="@neo",
+            actions=[SendTextAction(text="checkin")],
+        )
+
+        assert chat.chat_id == "@neo"

--- a/tests/test_sign_config_v2_to_v3.py
+++ b/tests/test_sign_config_v2_to_v3.py
@@ -1,5 +1,8 @@
 from datetime import time
 
+import pytest
+from pydantic import ValidationError
+
 from tg_signer.config import (
     ChooseOptionByImageAction,
     ClickKeyboardByTextAction,
@@ -164,3 +167,10 @@ class TestSignConfigV2ToCurrent:
 
         assert chat.chat_id == -1001234567890
         assert isinstance(chat.chat_id, int)
+
+    def test_sign_chat_v3_rejects_username_without_at_prefix(self):
+        with pytest.raises(ValidationError):
+            SignChatV3(
+                chat_id="neo",
+                actions=[SendTextAction(text="checkin")],
+            )

--- a/tests/test_sign_config_v2_to_v3.py
+++ b/tests/test_sign_config_v2_to_v3.py
@@ -155,3 +155,12 @@ class TestSignConfigV2ToCurrent:
         )
 
         assert chat.chat_id == "@neo"
+
+    def test_sign_chat_v3_coerces_numeric_string_chat_id_to_int(self):
+        chat = SignChatV3(
+            chat_id="-1001234567890",
+            actions=[SendTextAction(text="checkin")],
+        )
+
+        assert chat.chat_id == -1001234567890
+        assert isinstance(chat.chat_id, int)

--- a/tg_signer/cli/signer.py
+++ b/tg_signer/cli/signer.py
@@ -6,6 +6,7 @@ from typing import Optional
 import click
 from click import Context, HelpFormatter
 
+from tg_signer.config import parse_chat_id_or_username
 from tg_signer.core import UserSigner, get_proxy
 from tg_signer.sign_record_store import SignRecordStore
 
@@ -288,7 +289,7 @@ def run_once(obj, task_name, num_of_dialogs):
 @tg_signer.command(help='发送一次文本消息, 请确保当前会话已经"见过"该`chat_id`')
 @click.argument(
     "chat_id",
-    type=int,
+    type=str,
 )
 @click.argument("text")
 @click.option(
@@ -308,6 +309,7 @@ def run_once(obj, task_name, num_of_dialogs):
 @click.pass_obj
 def send_text(obj, chat_id, text, delete_after=None, message_thread_id=None):
     singer = get_signer(None, obj)
+    chat_id = parse_chat_id(chat_id)
     click.echo("将发送单次消息")
     singer.app_run(
         singer.send_text(
@@ -324,7 +326,7 @@ def send_text(obj, chat_id, text, delete_after=None, message_thread_id=None):
 )
 @click.argument(
     "chat_id",
-    type=int,
+    type=str,
 )
 @click.argument("emoji")
 @click.option(
@@ -344,6 +346,7 @@ def send_text(obj, chat_id, text, delete_after=None, message_thread_id=None):
 @click.pass_obj
 def send_dice(obj, chat_id, emoji, delete_after=None, message_thread_id=None):
     singer = get_signer(None, obj)
+    chat_id = parse_chat_id(chat_id)
     click.echo("将发送单次DICE消息")
     singer.app_run(
         singer.send_dice_cli(
@@ -364,11 +367,10 @@ def reconfig(obj, task_name):
 
 
 def parse_chat_id(chat_id: str):
-    chat_id = chat_id.strip()
     if chat_id.startswith("@"):
-        return chat_id[1:]
+        return parse_chat_id_or_username(chat_id)
     try:
-        return int(chat_id)
+        return parse_chat_id_or_username(chat_id)
     except ValueError as e:
         raise click.UsageError("chat_id为username时必须以@开头") from e
 
@@ -460,7 +462,7 @@ def import_(obj, task_name: str, file: str = None):
 @tg_signer.command(help="批量配置Telegram自带的定时发送消息功能")
 @click.argument(
     "chat_id",
-    type=int,
+    type=str,
 )
 @click.argument("text")
 @click.option(
@@ -501,6 +503,7 @@ def schedule_messages(
     obj, chat_id, text, crontab, next_times, random_seconds, message_thread_id
 ):
     signer = get_signer(None, obj)
+    chat_id = parse_chat_id(chat_id)
     signer.app_run(
         signer.schedule_messages(
             chat_id,
@@ -514,13 +517,14 @@ def schedule_messages(
 
 
 @tg_signer.command(help="显示已配置的定时消息")
-@click.argument("chat_id", type=int)
+@click.argument("chat_id", type=str)
 @click.pass_obj
 def list_schedule_messages(obj, chat_id):
     logging.root.setLevel(
         level=logging.WARNING,
     )
     signer = get_signer(None, obj)
+    chat_id = parse_chat_id(chat_id)
     signer.app_run(signer.get_schedule_messages(chat_id))
 
 

--- a/tg_signer/config.py
+++ b/tg_signer/config.py
@@ -17,6 +17,25 @@ from pydantic import AnyHttpUrl, BaseModel, ValidationError
 from pyrogram.types import Chat, Message
 from typing_extensions import Self, TypeAlias
 
+ChatId: TypeAlias = Union[int, str]
+
+
+def normalize_chat_username(value: str) -> str:
+    return value.strip().lstrip("@").lower()
+
+
+def parse_chat_id_or_username(value: Union[int, str]) -> ChatId:
+    if isinstance(value, int):
+        return value
+    value = str(value).strip()
+    if not value:
+        raise ValueError("chat_id cannot be empty")
+    if value.startswith("@"):
+        if len(value) == 1:
+            raise ValueError("username cannot be empty")
+        return value
+    return int(value)
+
 
 def get_display_width(text: str) -> int:
     """计算文本在终端中的显示宽度（考虑中文字符占2个字符位）"""
@@ -226,7 +245,7 @@ ActionT: TypeAlias = Union[
 
 class SignChatV3(BaseJSONConfig):
     version: ClassVar = 3
-    chat_id: int
+    chat_id: ChatId
     message_thread_id: Optional[int] = None
     name: Optional[str] = None
     delete_after: Optional[int] = None
@@ -356,10 +375,10 @@ class HttpCallback(BaseModel):
 
 
 class MatchConfig(BaseJSONConfig):
-    chat_id: Union[int, str] = None  # 聊天id或username
+    chat_id: ChatId = None  # 聊天id或username
     rule: MatchRuleT = "exact"  # 匹配规则
     rule_value: Optional[str] = None  # 规则值
-    from_user_ids: Optional[List[Union[int, str]]] = (
+    from_user_ids: Optional[List[ChatId]] = (
         None  # 发送者id或username，为空时，匹配所有人
     )
     always_ignore_me: bool = False  # 总是忽略自己发送的消息
@@ -369,7 +388,7 @@ class MatchConfig(BaseJSONConfig):
     send_text_search_regex: Optional[str] = None  # 用正则表达式从消息中提取发送内容
     delete_after: Optional[int] = None
     ignore_case: bool = True  # 忽略大小写
-    forward_to_chat_id: Optional[Union[int, str]] = (
+    forward_to_chat_id: Optional[ChatId] = (
         None  # 转发消息到该聊天，默认为消息来源
     )
     external_forwards: Optional[List[Union[UDPForward, HttpCallback]]] = (
@@ -390,7 +409,7 @@ class MatchConfig(BaseJSONConfig):
             (
                 "me"
                 if u in ["me", "self"]
-                else u.lower().strip("@")
+                else normalize_chat_username(u)
                 if isinstance(u, str)
                 else u
             )
@@ -436,7 +455,11 @@ class MatchConfig(BaseJSONConfig):
     def match_chat(self, chat: "Chat"):
         if isinstance(self.chat_id, int):
             return self.chat_id == chat.id
-        return self.chat_id == chat.username
+        if not chat.username:
+            return False
+        return normalize_chat_username(self.chat_id) == normalize_chat_username(
+            chat.username
+        )
 
     def match(self, message: "Message"):
         return self.match_chat(message.chat) and bool(

--- a/tg_signer/config.py
+++ b/tg_signer/config.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
 )
 
-from pydantic import AnyHttpUrl, BaseModel, ValidationError
+from pydantic import AnyHttpUrl, BaseModel, ValidationError, field_validator
 from pyrogram.types import Chat, Message
 from typing_extensions import Self, TypeAlias
 
@@ -35,6 +35,26 @@ def parse_chat_id_or_username(value: Union[int, str]) -> ChatId:
             raise ValueError("username cannot be empty")
         return value
     return int(value)
+
+
+def coerce_chat_id_or_username(value: Union[int, str]) -> ChatId:
+    if isinstance(value, int):
+        return value
+    value = str(value).strip()
+    if not value:
+        raise ValueError("chat_id cannot be empty")
+    if value == "@":
+        raise ValueError("username cannot be empty")
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def parse_optional_chat_id_or_username(value: Union[int, str, None]) -> Optional[ChatId]:
+    if value is None:
+        return None
+    return coerce_chat_id_or_username(value)
 
 
 def get_display_width(text: str) -> int:
@@ -252,6 +272,11 @@ class SignChatV3(BaseJSONConfig):
     actions: List[ActionT]
     action_interval: float = 1  # actions的间隔时间，单位秒
 
+    @field_validator("chat_id", mode="before")
+    @classmethod
+    def _parse_chat_id(cls, value):
+        return coerce_chat_id_or_username(value)
+
     def __repr__(self) -> str:
         return (
             f"SignChatV3(chat_id={self.chat_id}, "
@@ -397,6 +422,11 @@ class MatchConfig(BaseJSONConfig):
     push_via_server_chan: bool = False  # 将消息通过server酱推送
     server_chan_send_key: Optional[str] = None  # server酱的sendkey
 
+    @field_validator("chat_id", "forward_to_chat_id", mode="before")
+    @classmethod
+    def _parse_optional_chat_id(cls, value):
+        return parse_optional_chat_id_or_username(value)
+
     def __str__(self):
         return (
             f"{self.__class__.__name__}(chat_id={self.chat_id}, rule={self.rule}, rule_value={self.rule_value}),"
@@ -453,6 +483,8 @@ class MatchConfig(BaseJSONConfig):
         return False
 
     def match_chat(self, chat: "Chat"):
+        if self.chat_id is None:
+            return False
         if isinstance(self.chat_id, int):
             return self.chat_id == chat.id
         if not chat.username:

--- a/tg_signer/config.py
+++ b/tg_signer/config.py
@@ -37,26 +37,6 @@ def parse_chat_id_or_username(value: Union[int, str]) -> ChatId:
     return int(value)
 
 
-def coerce_chat_id_or_username(value: Union[int, str]) -> ChatId:
-    if isinstance(value, int):
-        return value
-    value = str(value).strip()
-    if not value:
-        raise ValueError("chat_id cannot be empty")
-    if value == "@":
-        raise ValueError("username cannot be empty")
-    try:
-        return int(value)
-    except ValueError:
-        return value
-
-
-def parse_optional_chat_id_or_username(value: Union[int, str, None]) -> Optional[ChatId]:
-    if value is None:
-        return None
-    return coerce_chat_id_or_username(value)
-
-
 def get_display_width(text: str) -> int:
     """计算文本在终端中的显示宽度（考虑中文字符占2个字符位）"""
     width = 0
@@ -275,7 +255,7 @@ class SignChatV3(BaseJSONConfig):
     @field_validator("chat_id", mode="before")
     @classmethod
     def _parse_chat_id(cls, value):
-        return coerce_chat_id_or_username(value)
+        return parse_chat_id_or_username(value)
 
     def __repr__(self) -> str:
         return (
@@ -400,7 +380,7 @@ class HttpCallback(BaseModel):
 
 
 class MatchConfig(BaseJSONConfig):
-    chat_id: ChatId = None  # 聊天id或username
+    chat_id: ChatId  # 聊天id或username
     rule: MatchRuleT = "exact"  # 匹配规则
     rule_value: Optional[str] = None  # 规则值
     from_user_ids: Optional[List[ChatId]] = (
@@ -413,19 +393,24 @@ class MatchConfig(BaseJSONConfig):
     send_text_search_regex: Optional[str] = None  # 用正则表达式从消息中提取发送内容
     delete_after: Optional[int] = None
     ignore_case: bool = True  # 忽略大小写
-    forward_to_chat_id: Optional[ChatId] = (
-        None  # 转发消息到该聊天，默认为消息来源
-    )
+    forward_to_chat_id: Optional[ChatId] = None  # 转发消息到该聊天，默认为消息来源
     external_forwards: Optional[List[Union[UDPForward, HttpCallback]]] = (
         None  # 转发到外部
     )
     push_via_server_chan: bool = False  # 将消息通过server酱推送
     server_chan_send_key: Optional[str] = None  # server酱的sendkey
 
-    @field_validator("chat_id", "forward_to_chat_id", mode="before")
+    @field_validator("chat_id", mode="before")
+    @classmethod
+    def _parse_chat_id(cls, value):
+        return parse_chat_id_or_username(value)
+
+    @field_validator("forward_to_chat_id", mode="before")
     @classmethod
     def _parse_optional_chat_id(cls, value):
-        return parse_optional_chat_id_or_username(value)
+        if value is None:
+            return None
+        return parse_chat_id_or_username(value)
 
     def __str__(self):
         return (
@@ -483,8 +468,6 @@ class MatchConfig(BaseJSONConfig):
         return False
 
     def match_chat(self, chat: "Chat"):
-        if self.chat_id is None:
-            return False
         if isinstance(self.chat_id, int):
             return self.chat_id == chat.id
         if not chat.username:

--- a/tg_signer/core.py
+++ b/tg_signer/core.py
@@ -44,11 +44,13 @@ from pyrogram.types import (
 from tg_signer.config import (
     ActionT,
     BaseJSONConfig,
+    ChatId,
     ChooseOptionByImageAction,
     ClickKeyboardByTextAction,
     HttpCallback,
     MatchConfig,
     MonitorConfig,
+    parse_chat_id_or_username,
     ReplyByCalculationProblemAction,
     SendDiceAction,
     SendTextAction,
@@ -139,7 +141,7 @@ _API_MIN_INTERVAL_SECONDS = 0.35
 _API_FLOODWAIT_PADDING_SECONDS = 0.5
 _API_MAX_FLOODWAIT_RETRIES = 2
 
-RouteKey = tuple[int, Optional[int]]
+RouteKey = tuple[ChatId, Optional[int]]
 
 
 class Client(SafeGetForumTopics, BaseClient):
@@ -716,6 +718,7 @@ class UserSignerWorkerContext(BaseModel):
 
     waiter: Waiter
     sign_chats: defaultdict[RouteKey, list[SignChatV3]]  # 签到配置列表
+    resolved_route_keys: dict[RouteKey, RouteKey]
     chat_messages: defaultdict[
         RouteKey,
         Annotated[
@@ -736,6 +739,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
         return UserSignerWorkerContext(
             waiter=Waiter(),
             sign_chats=defaultdict(list),
+            resolved_route_keys={},
             chat_messages=defaultdict(dict),
             waiting_message=None,
         )
@@ -746,9 +750,34 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
 
     @staticmethod
     def get_route_key(
-        chat_id: int, message_thread_id: Optional[int] = None
+        chat_id: ChatId, message_thread_id: Optional[int] = None
     ) -> RouteKey:
         return chat_id, message_thread_id
+
+    async def resolve_chat_route_key(self, chat: SignChatV3) -> RouteKey:
+        route_key = self.get_route_key(chat.chat_id, chat.message_thread_id)
+        resolved_route_key = self.context.resolved_route_keys.get(route_key)
+        if resolved_route_key is not None:
+            return resolved_route_key
+        if isinstance(chat.chat_id, int):
+            resolved_route_key = route_key
+        else:
+            resolved_chat = await self._call_telegram_api(
+                "contacts.ResolveUsername",
+                lambda: self.app.get_chat(chat.chat_id),
+            )
+            resolved_route_key = self.get_route_key(
+                resolved_chat.id, chat.message_thread_id
+            )
+        self.context.resolved_route_keys[route_key] = resolved_route_key
+        return resolved_route_key
+
+    def get_runtime_route_key(self, chat: SignChatV3) -> RouteKey:
+        route_key = self.get_route_key(chat.chat_id, chat.message_thread_id)
+        context = getattr(self, "context", None)
+        if isinstance(context, UserSignerWorkerContext):
+            return context.resolved_route_keys.get(route_key, route_key)
+        return route_key
 
     @property
     def sign_record_file(self):
@@ -813,7 +842,9 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
 
     def ask_one(self) -> SignChatV3:
         input_ = UserInput(numbering_lang="chinese_simple")
-        chat_id = int(input_("Chat ID（登录时最近对话输出中的ID）: "))
+        chat_id = parse_chat_id_or_username(
+            input_("Chat ID（登录时最近对话输出中的ID或@username）: ")
+        )
         name = input_("Chat名称（可选）: ")
         use_message_thread = (
             input_("是否发送到话题（message_thread_id）？(y/N)：").strip().lower()
@@ -987,7 +1018,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
 
         async def sign_once():
             for chat in config.chats:
-                route_key = self.get_route_key(chat.chat_id, chat.message_thread_id)
+                route_key = await self.resolve_chat_route_key(chat)
                 self.context.sign_chats[route_key].append(chat)
                 try:
                     await self.sign_a_chat(chat)
@@ -1050,7 +1081,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
 
     async def send_text(
         self,
-        chat_id: int,
+        chat_id: Union[int, str],
         text: str,
         delete_after: int = None,
         message_thread_id: Optional[int] = None,
@@ -1185,7 +1216,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
         return False
 
     async def wait_for(self, chat: SignChatV3, action: ActionT, timeout=10):
-        route_key = self.get_route_key(chat.chat_id, chat.message_thread_id)
+        route_key = self.get_runtime_route_key(chat)
         if isinstance(action, SendTextAction):
             return await self.send_message(
                 chat.chat_id,

--- a/tg_signer/core.py
+++ b/tg_signer/core.py
@@ -50,7 +50,6 @@ from tg_signer.config import (
     HttpCallback,
     MatchConfig,
     MonitorConfig,
-    parse_chat_id_or_username,
     ReplyByCalculationProblemAction,
     SendDiceAction,
     SendTextAction,
@@ -58,6 +57,7 @@ from tg_signer.config import (
     SignConfigV3,
     SupportAction,
     UDPForward,
+    parse_chat_id_or_username,
 )
 
 from ._kurigram import SafeGetForumTopics
@@ -549,6 +549,7 @@ class BaseUserWorker(Generic[ConfigT]):
         :param chat_id:
         :param text:
         :param delete_after: 秒, 发送消息后进行删除，``None`` 表示不删除, ``0`` 表示立即删除.
+        :param message_thread_id: 群组内话题ID
         :param kwargs:
         :return:
         """
@@ -774,10 +775,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
 
     def get_runtime_route_key(self, chat: SignChatV3) -> RouteKey:
         route_key = self.get_route_key(chat.chat_id, chat.message_thread_id)
-        context = getattr(self, "context", None)
-        if isinstance(context, UserSignerWorkerContext):
-            return context.resolved_route_keys.get(route_key, route_key)
-        return route_key
+        return self.context.resolved_route_keys.get(route_key, route_key)
 
     @property
     def sign_record_file(self):
@@ -1218,7 +1216,6 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
         return False
 
     async def wait_for(self, chat: SignChatV3, action: ActionT, timeout=10):
-        route_key = self.get_runtime_route_key(chat)
         if isinstance(action, SendTextAction):
             return await self.send_message(
                 chat.chat_id,
@@ -1233,6 +1230,7 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
                 chat.delete_after,
                 message_thread_id=chat.message_thread_id,
             )
+        route_key = self.get_runtime_route_key(chat)
         self.context.waiter.add(route_key)
         start = time.perf_counter()
         last_message = None

--- a/tg_signer/core.py
+++ b/tg_signer/core.py
@@ -1018,16 +1018,18 @@ class UserSigner(BaseUserWorker[SignConfigV3]):
 
         async def sign_once():
             for chat in config.chats:
-                route_key = await self.resolve_chat_route_key(chat)
-                self.context.sign_chats[route_key].append(chat)
+                route_key = None
                 try:
+                    route_key = await self.resolve_chat_route_key(chat)
+                    self.context.sign_chats[route_key].append(chat)
                     await self.sign_a_chat(chat)
                 except errors.RPCError as _e:
                     self.log(f"签到失败: {_e} \nchat: \n{chat}")
                     logger.warning(_e, exc_info=True)
                     continue
 
-                self.context.chat_messages[route_key].clear()
+                if route_key is not None:
+                    self.context.chat_messages[route_key].clear()
                 await asyncio.sleep(config.sign_interval)
             self.persist_sign_record(sign_record, str(now.date()), now.isoformat())
 

--- a/tg_signer/webui/app.py
+++ b/tg_signer/webui/app.py
@@ -28,7 +28,7 @@ from tg_signer.webui.schema_utils import clean_schema
 SIGNER_TEMPLATE: Dict[str, object] = {
     "chats": [
         {
-            "chat_id": 123456789,
+            "chat_id": "@channel_or_user",
             "message_thread_id": None,
             "name": "示例任务",
             "delete_after": None,

--- a/tg_signer/webui/interactive.py
+++ b/tg_signer/webui/interactive.py
@@ -8,13 +8,13 @@ from tg_signer.config import (
     ActionT,
     ChooseOptionByImageAction,
     ClickKeyboardByTextAction,
-    parse_chat_id_or_username,
     ReplyByCalculationProblemAction,
     SendDiceAction,
     SendTextAction,
     SignChatV3,
     SignConfigV3,
     SupportAction,
+    parse_chat_id_or_username,
 )
 from tg_signer.webui.data import load_user_infos, save_config
 

--- a/tg_signer/webui/interactive.py
+++ b/tg_signer/webui/interactive.py
@@ -8,6 +8,7 @@ from tg_signer.config import (
     ActionT,
     ChooseOptionByImageAction,
     ClickKeyboardByTextAction,
+    parse_chat_id_or_username,
     ReplyByCalculationProblemAction,
     SendDiceAction,
     SendTextAction,
@@ -240,9 +241,9 @@ class InteractiveSignerConfig:
             with ui.grid(columns=2).classes("w-full gap-4 mb-4"):
                 id_input = (
                     ui.input(
-                        label="Chat ID",
+                        label="Chat ID / @username",
                         value=str(d_chat_id) if d_chat_id else "",
-                        placeholder="整数ID (点击选择)",
+                        placeholder="整数ID 或 @username (点击选择)",
                     )
                     .props("outlined")
                     .on("click", show_import_dialog)
@@ -402,9 +403,11 @@ class InteractiveSignerConfig:
             def save_chat():
                 try:
                     try:
-                        cid = int(id_input.value)
-                    except (ValueError, TypeError):
-                        raise ValueError("Chat ID不能为空且必须是整数")
+                        cid = parse_chat_id_or_username(id_input.value)
+                    except (ValueError, TypeError) as e:
+                        raise ValueError(
+                            "Chat ID不能为空，且必须是整数ID或以@开头的username"
+                        ) from e
 
                     if not d_actions:
                         raise ValueError("至少需要配置一个动作")


### PR DESCRIPTION
## Summary
- allow signer configs to accept `@username` chat ids in CLI prompts and the WebUI
- resolve username-based signer routes to the runtime numeric chat id before waiting for replies
- normalize monitor chat username matching so `@neo` works as documented

## Root cause
Signer config entry points still forced `chat_id` to `int`, while the runtime message router indexed reply callbacks by numeric `message.chat.id`. That meant `@username` values either could not be configured at all, or could send the first message but fail to match follow-up replies.

Monitor config had a related mismatch: the docs require `@username`, but matching compared the raw config value against `chat.username` without stripping the leading `@`.

## Changes
- widen `SignChatV3.chat_id` to support integer ids and usernames
- add a shared parser for `chat_id` / `@username` inputs
- resolve signer route keys from username to numeric chat id before registering per-chat callbacks
- reuse resolved route keys when waiting for follow-up messages
- update the signer WebUI input and template to accept usernames
- add regression coverage for username route resolution and `@username` monitor matching
- document username usage in both READMEs

## Validation
- `pytest -q tests/test_match_config.py tests/test_sign_config_v2_to_v3.py`
- manual async checks covering signer username route resolution, reply routing, and waiter lookup
- `python -m compileall tg_signer`
